### PR TITLE
Add pair command

### DIFF
--- a/rflink/__main__.py
+++ b/rflink/__main__.py
@@ -2,7 +2,7 @@
 
 Usage:
   rflink [-v | -vv] [options]
-  rflink [-v | -vv] [options] [--repeat <repeat>] (on|off|allon|alloff|up|down|stop) <id>
+  rflink [-v | -vv] [options] [--repeat <repeat>] (on|off|allon|alloff|up|down|stop|pair) <id>
   rflink (-h | --help)
   rflink --version
 
@@ -43,7 +43,7 @@ PROTOCOLS = {
     'repeat': RepeaterProtocol,
 }
 
-ALL_COMMANDS = ['on', 'off', 'allon', 'alloff', 'up', 'down', 'stop']
+ALL_COMMANDS = ['on', 'off', 'allon', 'alloff', 'up', 'down', 'stop', 'pair']
 
 
 def main(argv=sys.argv[1:], loop=None):


### PR DESCRIPTION
Some devices require a special `pair` command when learning a new command, like the EMW100Rs I have (also known as Everflourish). With this PR I can put an outlet into pairing mode and run:
```shell
rflink -vv --repeat=2 -p /dev/tty.usbmodem14101 pair emw100_aabb_01
```
After that I can turn `on` or `off´ with:
```shell
rflink -vv --repeat=2 -p /dev/tty.usbmodem14101 on emw100_aabb_01
rflink -vv --repeat=2 -p /dev/tty.usbmodem14101 off emw100_aabb_01
```