### PR TITLE
stable generating of reverse packet_fields map.

### DIFF
--- a/rflink/parser.py
+++ b/rflink/parser.py
@@ -458,7 +458,7 @@ def packet_events(packet: dict) -> Generator:
     ... }))
     >>> assert {'id': 'newkaku_000001_01', 'command': 'on'} in y
     """
-    field_abbrev = {v: k for k, v in PACKET_FIELDS.items()}
+    field_abbrev = {v: k for k, v in sorted(PACKET_FIELDS.items(), key=lambda x: (x[1], x[0]), reverse=True)}
 
     packet_id = serialize_packet_id(packet)
     events = {f: v for f, v in packet.items() if f in field_abbrev}


### PR DESCRIPTION
In PACKET_FIELDS there are some items that maps multiple keys into same string values. Order of dict items() is not stable among python interpreter instances. This causes to generate random ids among multiple interpreter executions. (In my setup I can see "alectov1_XXX_rain" and "alectov1_XXX_raintot" switching among multiple script execution). This is simple attempt to solve this issue.