### PR TITLE
Fix setuptools warning about trailing newline in version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def version_from_git():
     """Acquire package version form current git tag."""
     return check_output(
         ["git", "describe", "--tags", "--abbrev=0"], universal_newlines=True
-    )
+    ).strip()
 
 
 setup(


### PR DESCRIPTION
```
$ python setup.py build
[...]/lib/python3.8/site-packages/setuptools/dist.py:471: UserWarning: Normalizing '0.0.49
' to '0.0.49'
```