### PR TITLE
Enable TCP_KEEPALIVE on demand

### DIFF
--- a/rflink/__main__.py
+++ b/rflink/__main__.py
@@ -105,3 +105,8 @@ def main(
         loop.run_forever()
     finally:
         loop.close()
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()

--- a/rflink/__main__.py
+++ b/rflink/__main__.py
@@ -7,16 +7,20 @@ Usage:
   rflink --version
 
 Options:
-  -p --port=<port>   Serial port to connect to [default: /dev/ttyACM0],
-                       or TCP port in TCP mode.
-  --baud=<baud>      Serial baud rate [default: 57600].
-  --host=<host>      TCP mode, connect to host instead of serial port.
-  --repeat=<repeat>  How often to repeat a command [default: 1].
-  -m=<handling>      How to handle incoming packets [default: event].
-  --ignore=<ignore>  List of device ids to ignore, wildcards supported.
-  -h --help          Show this screen.
-  -v                 Increase verbosity
-  --version          Show version.
+  -p --port=<port>         Serial port to connect to [default: /dev/ttyACM0],
+                             or TCP port in TCP mode.
+  --baud=<baud>            Serial baud rate [default: 57600].
+  --host=<host>            TCP mode, connect to host instead of serial port.
+  --repeat=<repeat>        How often to repeat a command [default: 1].
+  --keepalive              Enable TCP Keepalive [default: False].
+  --keepidle=<NUMBER>      TCP Keepalive IDLE timer [default: None]
+  --keepinterval=<NUMBER>  TCP Keepalive Interval timer
+  --keepcount=<NUMBER>     TCP Keepalive missed ACK count
+  -m=<handling>            How to handle incoming packets [default: event].
+  --ignore=<ignore>        List of device ids to ignore, wildcards supported.
+  -h --help                Show this screen.
+  -v                       Increase verbosity
+  --version                Show version.
 """
 
 import asyncio
@@ -79,6 +83,18 @@ def main(
     else:
         protocol_type = PROTOCOLS[args["-m"]]
 
+    keep_idle = None
+    if type(args["--keepidle"]) is str:
+        keep_idle = int(args["--keepidle"])
+
+    keep_interval = None
+    if type(args["--keepinterval"]) is str:
+        keep_interval = int(args["--keepinterval"])
+
+    keep_count = None
+    if type(args["--keepcount"]) is str:
+        keep_count = int(args["--keepcount"])
+
     conn = create_rflink_connection(
         protocol=protocol_type,
         host=args["--host"],
@@ -86,6 +102,10 @@ def main(
         baud=args["--baud"],
         loop=loop,
         ignore=ignore,
+        keep_alive=args["--keepalive"],
+        keep_idle=keep_idle,
+        keep_interval=keep_interval,
+        keep_count=keep_count
     )
 
     transport, protocol = loop.run_until_complete(conn)

--- a/rflink/protocol.py
+++ b/rflink/protocol.py
@@ -23,6 +23,8 @@ from typing import (
     overload,
 )
 
+import socket
+
 from serial_asyncio import create_serial_connection
 
 from .parser import (
@@ -64,11 +66,42 @@ class ProtocolBase(asyncio.Protocol):
         self.buffer = ""
         self.packet_callback = None  # type: Optional[Callable[[PacketType], None]]
         self.disconnect_callback = disconnect_callback
+        self.keep_alive = False
+        self.keep_idle = 10      # seconds
+        self.keep_interval = 10  # seconds
+        self.keep_count = 3      # count
+        if kwargs is not None and type(kwargs) is dict:
+            value = kwargs.get('keep_alive')
+            if type(value) is bool:
+                self.keep_alive = value
+                value = kwargs.get('keep_idle')
+                if type(value) is int:
+                    self.keep_idle = value
+                value = kwargs.get('keep_interval')
+                if type(value) is int:
+                    self.keep_interval = value
+                value = kwargs.get('keep_count')
+                if type(value) is int:
+                    self.keep_count = value
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """Just logging for now."""
         self.transport = transport
         log.debug("connected")
+        sock = transport.get_extra_info('socket')
+        if self.keep_alive and socket is not None:
+            log.debug("applying TCP KEEPALIVE settings: IDLE={}/INTVL={}/CNT={}".format(self.keep_idle,
+                                                                                         self.keep_interval,
+                                                                                         self.keep_count))
+            if hasattr(socket, "SO_KEEPALIVE"):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            if hasattr(socket, "TCP_KEEPIDLE"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, self.keep_idle)
+            if hasattr(socket, "TCP_KEEPINTVL"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, self.keep_interval)
+            if hasattr(socket, "TCP_KEEPCNT"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, self.keep_count)
+
 
     def data_received(self, data: bytes) -> None:
         """Add incoming data to buffer."""
@@ -393,6 +426,10 @@ def create_rflink_connection(
     port: Union[None, str, int] = None,
     host: Optional[str] = None,
     baud: int = 57600,
+    keep_alive=False,
+    keep_idle=None,
+    keep_interval=None,
+    keep_count=None,
     protocol: Type[ProtocolBase] = RflinkProtocol,
     packet_callback: Optional[Callable[[PacketType], None]] = None,
     event_callback: Optional[Callable[[PacketType], None]] = None,
@@ -411,7 +448,12 @@ def create_rflink_connection(
         event_callback=event_callback,
         disconnect_callback=disconnect_callback,
         ignore=ignore if ignore else [],
+        keep_alive=keep_alive,
+        keep_idle=keep_idle,
+        keep_interval=keep_interval,
+        keep_count=keep_count
     )
+
 
     # setup serial connection if no transport specified
     if host:


### PR DESCRIPTION
from issue #54 

python-rflink>python -m rflink --host=192.168.0.31 --port=1900 -vv --keepalive --keepidle=3 --keepinterval=3 --keepcount=3
DEBUG:asyncio:Using proactor: IocpProactor
DEBUG:rflink.protocol:connected
DEBUG:rflink.protocol:applying TCP KEEPALIVE settings: IDLE=3/INTVL=3/CNT=3
ERROR:rflink.protocol:disconnected due to exception