### PR TITLE
Remove dependency on deprecated functionality

### DIFF
--- a/rflink/__main__.py
+++ b/rflink/__main__.py
@@ -28,6 +28,8 @@ from typing import Dict, Optional, Sequence, Type  # noqa: unused-import
 
 from docopt import docopt
 
+from rflink.asyncio_utils import get_or_create_event_loop
+
 from .protocol import (  # noqa: unused-import
     CommandSerialization,
     EventHandling,
@@ -63,8 +65,7 @@ def main(
         level = logging.DEBUG
     logging.basicConfig(level=level)
 
-    if not loop:
-        loop = asyncio.get_event_loop()
+    loop = get_or_create_event_loop(loop)
 
     if args["--ignore"]:
         ignore = args["--ignore"].split(",")

--- a/rflink/asyncio_utils.py
+++ b/rflink/asyncio_utils.py
@@ -1,0 +1,19 @@
+"""Async helper utilities."""
+
+import asyncio
+from typing import Optional
+
+
+def get_or_create_event_loop(
+    loop: Optional[asyncio.AbstractEventLoop] = None
+) -> asyncio.AbstractEventLoop:
+    """Get existing event loop or create a new one.
+
+    Prefers the running loop if in async context, otherwise creates new.
+    """
+    if loop is not None:
+        return loop
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.new_event_loop()

--- a/rflink/protocol.py
+++ b/rflink/protocol.py
@@ -7,6 +7,8 @@ import asyncio
 import concurrent
 import logging
 import socket
+
+from rflink.asyncio_utils import get_or_create_event_loop
 from datetime import timedelta
 from fnmatch import fnmatchcase
 from functools import partial
@@ -59,10 +61,7 @@ class ProtocolBase(asyncio.Protocol):
         **kwargs: Any,
     ) -> None:
         """Initialize class."""
-        if loop:
-            self.loop = loop
-        else:
-            self.loop = asyncio.get_event_loop()
+        self.loop = get_or_create_event_loop(loop)
         self.packet = ""
         self.buffer = ""
         self.packet_callback = None  # type: Optional[Callable[[PacketType], None]]
@@ -426,8 +425,7 @@ def create_rflink_connection(
     loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> "Coroutine[Any, Any, tuple[asyncio.Transport, asyncio.Protocol]]":
     """Create Rflink manager class, returns transport coroutine."""
-    if loop is None:
-        loop = asyncio.get_event_loop()
+    loop = get_or_create_event_loop(loop)
     # use default protocol if not specified
     protocol_factory = partial(
         protocol,

--- a/rflinkproxy/__main__.py
+++ b/rflinkproxy/__main__.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, cast
 from docopt import docopt
 from serial_asyncio_fast import create_serial_connection
 
+from rflink.asyncio_utils import get_or_create_event_loop
 from rflink.parser import (
     DELIM,
     PacketHeader,
@@ -288,8 +289,7 @@ def main(argv=sys.argv[1:], loop=None):
         level = logging.DEBUG
     logging.basicConfig(level=level)
 
-    if not loop:
-        loop = asyncio.get_event_loop()
+    loop = get_or_create_event_loop(loop)
 
     host = args["--host"]
     port = args["--port"]


### PR DESCRIPTION
Since Python 3.14 the get_event_loop function throws a runtime error when no event_loop is defined yet. So using get_event_loop when no event loop is defined yet is not possible anymore. So I created a function to mimic this behavior. This ensures the event_loop context to be created when there is none present (when using the CLI for example), or uses the existing one when called from another library in an async context.

The deprecation is documented [here](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop)

Thanks for this nice library and CLI!